### PR TITLE
Potential fix for code scanning alert no. 2: Use of a broken or weak cryptographic hashing algorithm on sensitive data

### DIFF
--- a/cryptguard/hidden_volume.py
+++ b/cryptguard/hidden_volume.py
@@ -6,7 +6,7 @@ import datetime
 import time
 import random
 import secrets
-import hashlib
+from argon2 import PasswordHasher
 import getpass
 
 from cryptography.hazmat.primitives.ciphers.aead import ChaCha20Poly1305
@@ -342,7 +342,8 @@ def change_real_volume_password():
 
     print("\nEnter ephemeral token for real volume access:")
     token = getpass.getpass("> ")
-    token_hash = hashlib.sha256(token.encode()).hexdigest()
+    ph = PasswordHasher()
+    token_hash = ph.hash(token)
 
     print("\nAuthenticate real volume to decrypt the real part (password + optional key file):")
     real_pwd, _ = choose_auth_method()
@@ -360,7 +361,12 @@ def change_real_volume_password():
             input("\nPress Enter to continue...")
             return
 
-    if token_hash != meta_inner.get('part2_token_hash'):
+    try:
+        ph.verify(meta_inner.get('part2_token_hash'), token)
+    except:
+        print("Incorrect token!")
+        input("\nPress Enter to continue...")
+        return
         print("Incorrect token!")
         input("\nPress Enter to continue...")
         return


### PR DESCRIPTION
Potential fix for [https://github.com/Crypt-Guard/CryptGuard/security/code-scanning/2](https://github.com/Crypt-Guard/CryptGuard/security/code-scanning/2)

To fix the problem, we should replace the use of SHA-256 with a more secure hashing algorithm that is suitable for sensitive data, such as Argon2. Argon2 is a modern, secure, and computationally expensive hashing algorithm that is designed to be resistant to brute-force attacks. We will use the `argon2-cffi` library to implement this change.

Specifically, we will:
1. Import the `PasswordHasher` class from the `argon2` module.
2. Replace the SHA-256 hashing of the token with Argon2 hashing.
3. Update the comparison of the token hash to use Argon2's verification method.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
